### PR TITLE
support cmake3.18+ (#9)

### DIFF
--- a/scripts/build_tool/cmake_version.sh
+++ b/scripts/build_tool/cmake_version.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+# **********************************************************
+# Copyright (c) 2020 Xuhpclab. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file for more information.
+# **********************************************************
+
+cmake_version_str=$(cmake --version | grep version)
+
+cmake_version_str=${cmake_version_str#"cmake version"}
+### get version code
+MAJOR="${cmake_version_str%.*}"
+
+echo $MAJOR

--- a/scripts/build_tool/make.sh
+++ b/scripts/build_tool/make.sh
@@ -48,9 +48,37 @@ cd $BUILD_PATH
 # run cmake
 echo -e "Running Cmake .. (See \033[34m$CMAKE_LOG_FILE\033[0m for detail)"
 if [ "$DEBUG_MODE" == "true" ] ; then
-    cmake -DDEBUG=ON $DYNAMORIO_ROOT_PATH -DCMAKE_C_COMPILER=gcc $DISABLE_WARNINGS >$CMAKE_LOG_FILE 2>&1 && echo -e "\033[32m Cmake successfully! \033[0m" || (echo -e "\033[31m Cmake fail! \033[0m"; exit -1)
+    cmake $DYNAMORIO_ROOT_PATH \
+        -DDEBUG=ON \
+        -DINTERNAL=ON \
+        -DBUILD_DOCS=OFF \
+        -DBUILD_SAMPLES=OFF \
+        -DBUILD_TESTS=OFF \
+        -DCMAKE_C_COMPILER=gcc \
+        $DISABLE_WARNINGS >$CMAKE_LOG_FILE 2>&1 && \
+        echo -e "\033[32m Cmake successfully! \033[0m" || (echo -e "\033[31m Cmake fail! \033[0m"; exit -1)
 else
-    cmake $DYNAMORIO_ROOT_PATH -DCMAKE_C_COMPILER=gcc $DISABLE_WARNINGS >$CMAKE_LOG_FILE 2>&1 && echo -e "\033[32m Cmake successfully! \033[0m" || (echo -e "\033[31m Cmake fail! \033[0m"; exit -1)
+    cmake $DYNAMORIO_ROOT_PATH \
+        -DBUILD_DOCS=OFF \
+        -DBUILD_SAMPLES=OFF \
+        -DBUILD_TESTS=OFF \
+        -DCMAKE_C_COMPILER=gcc \
+        $DISABLE_WARNINGS >$CMAKE_LOG_FILE 2>&1 && \
+        echo -e "\033[32m Cmake successfully! \033[0m" || (echo -e "\033[31m Cmake fail! \033[0m"; exit -1)
+fi
+
+# temp solution to build_error(#9)
+CMAKE_VERSION=$($CUR_DIR/cmake_version.sh)
+BUILD_ERROR_MIN_CMAKE_VERSION="3.18"
+if [ ${CMAKE_VERSION%.*} -eq ${BUILD_ERROR_MIN_CMAKE_VERSION%.*} ] ; then
+    if [ ${CMAKE_VERSION#*.} -ge ${BUILD_ERROR_MIN_CMAKE_VERSION#*.} ] ; then
+        NEED_FIX=1
+    fi
+elif [ ${CMAKE_VERSION%.*} -gt ${BUILD_ERROR_MIN_CMAKE_VERSION%.*} ] ; then
+    NEED_FIX=1
+fi
+if [ ${NEED_FIX} -eq 1 ] ; then
+    $CUR_DIR/temp_solution/fix_build_error_9.sh $BUILD_PATH
 fi
 
 # start make

--- a/scripts/build_tool/remake.sh
+++ b/scripts/build_tool/remake.sh
@@ -28,6 +28,21 @@ echo -e "Enter \033[34m$BUILD_PATH\033[0m .."
 # enter BUILD_PATH
 cd $BUILD_PATH
 
+# temp solution to build_error(#9)
+CMAKE_VERSION=$($CUR_DIR/cmake_version.sh)
+BUILD_ERROR_MIN_CMAKE_VERSION="3.18"
+if [ ${CMAKE_VERSION%.*} -eq ${BUILD_ERROR_MIN_CMAKE_VERSION%.*} ] ; then
+    if [ ${CMAKE_VERSION#*.} -ge ${BUILD_ERROR_MIN_CMAKE_VERSION#*.} ] ; then
+        NEED_FIX=1
+    fi
+elif [ ${CMAKE_VERSION%.*} -gt ${BUILD_ERROR_MIN_CMAKE_VERSION%.*} ] ; then
+    NEED_FIX=1
+fi
+if [ ${NEED_FIX} -eq 1 ] ; then
+    make rebuild_cache
+    $CUR_DIR/temp_solution/fix_build_error_9.sh $BUILD_PATH
+fi
+
 # start remake
 echo -e "Running remake .. (See \033[34m$MAKE_LOG_FILE\033[0m for detail)"
 make -j >$MAKE_LOG_FILE 2>&1 && echo -e "\033[32m Remake successfully! \033[0m" || (echo -e "\033[31m Remake fail! \033[0m"; exit -1)

--- a/scripts/build_tool/temp_solution/fix_build_error_9.sh
+++ b/scripts/build_tool/temp_solution/fix_build_error_9.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+# **********************************************************
+# Copyright (c) 2020 Xuhpclab. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file for more information.
+# **********************************************************
+
+CUR_DIR=$(cd "$(dirname "$0")";pwd)
+
+BUILD_DIR=$1
+
+echo "fix build error 9"
+python3 $CUR_DIR/flags_make_autofix.py $BUILD_DIR/ext/drwrap/CMakeFiles/drwrap.dir/flags.make
+python3 $CUR_DIR/flags_make_autofix.py $BUILD_DIR/core/CMakeFiles/dynamorio.dir/flags.make
+python3 $CUR_DIR/flags_make_autofix.py $BUILD_DIR/core/CMakeFiles/dynamorio_static.dir/flags.make

--- a/scripts/build_tool/temp_solution/flags_make_autofix.py
+++ b/scripts/build_tool/temp_solution/flags_make_autofix.py
@@ -1,0 +1,15 @@
+#! /usr/bin/python3
+
+# **********************************************************
+# Copyright (c) 2020 Xuhpclab. All rights reserved.
+# Licensed under the MIT License.
+# See LICENSE file for more information.
+# **********************************************************
+
+import sys
+
+filePath = sys.argv[1]
+
+with open(filePath, "r+") as f:
+    read_data = f.read()
+    f.write(read_data.replace('--defsym ', '-D'))


### PR DESCRIPTION
To support NinJa, cmake 3.18+ changed generated defined flags for asm compiling. Specifically, it replaces "-D" with "--defsym" in flags.make. Dynamorio did not update for handling this change.

Without changing the compilation architecture of dynamorio, we fix this error by using a temp solution that is just running a script to replace "--defsym " to "-D" between cmake and make.